### PR TITLE
Add GitHub Skills activity to the extracurricular activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub training. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Tuesdays and Thursdays, 2:00 PM - 3:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This pull request adds the GitHub Skills activity to the list of extracurricular activities, addressing issue #6.

## Changes Made
- Added GitHub Skills activity with a description referencing the GitHub Certifications program
- Scheduled for Tuesdays and Thursdays, 2:00 PM - 3:00 PM
- Set capacity to 25 participants
- Activity is now available for student registration

## Related Issues
Closes #6 - Missing Activity: GitHub Skills

## Testing
The activity can now be viewed in the activities list at `/activities` endpoint and students can register for it using the signup endpoint.